### PR TITLE
Support node v18 and drop node v12

### DIFF
--- a/.github/workflows/ci-module.yml
+++ b/.github/workflows/ci-module.yml
@@ -10,3 +10,5 @@ on:
 jobs:
   test:
     uses: hapijs/.github/.github/workflows/ci-module.yml@master
+    with:
+      min-node-version: 14

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,5 +1,6 @@
-Copyright (c) 2014-2020, Sideway Inc, and project contributors  
-Copyright (c) 2014, Walmart.  
+Copyright (c) 2014-2022, Project contributors
+Copyright (c) 2014-2020, Sideway Inc
+Copyright (c) 2014, Walmart.
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:

--- a/lib/index.js
+++ b/lib/index.js
@@ -6,162 +6,164 @@ const Hoek = require('@hapi/hoek');
 const internals = {};
 
 
-exports = module.exports = internals.Vise = function (chunks) {
+exports.Vise = class Vise {
 
-    this.length = 0;
-    this._chunks = [];
-    this._offset = 0;
+    constructor(chunks) {
 
-    if (chunks) {
-        chunks = [].concat(chunks);
-        for (let i = 0; i < chunks.length; ++i) {
-            this.push(chunks[i]);
-        }
-    }
-};
+        this.length = 0;
+        this._chunks = [];
+        this._offset = 0;
 
-
-internals.Vise.prototype.push = function (chunk) {
-
-    Hoek.assert(Buffer.isBuffer(chunk), 'Chunk must be a buffer');
-
-    const item = {
-        data: chunk,
-        length: chunk.length,
-        offset: this.length + this._offset,
-        index: this._chunks.length
-    };
-
-    this._chunks.push(item);
-    this.length += chunk.length;
-};
-
-
-internals.Vise.prototype.shift = function (length) {
-
-    if (!length) {
-        return [];
-    }
-
-    const prevOffset = this._offset;
-    const item = this._chunkAt(length);
-
-    let dropTo = this._chunks.length;
-    this._offset = 0;
-
-    if (item) {
-        dropTo = item.chunk.index;
-        this._offset = item.offset;
-    }
-
-    // Drop lower chunks
-
-    const chunks = [];
-    for (let i = 0; i < dropTo; ++i) {
-        const chunk = this._chunks.shift();
-        if (i === 0 &&
-            prevOffset) {
-
-            chunks.push(chunk.data.slice(prevOffset));
-        }
-        else {
-            chunks.push(chunk.data);
-        }
-    }
-
-    if (this._offset) {
-        chunks.push(item.chunk.data.slice(dropTo ? 0 : prevOffset, this._offset));
-    }
-
-    // Recalculate existing chunks
-
-    this.length = 0;
-    for (let i = 0; i < this._chunks.length; ++i) {
-        const chunk = this._chunks[i];
-        chunk.offset = this.length,
-        chunk.index = i;
-
-        this.length += chunk.length;
-    }
-
-    this.length -= this._offset;
-
-    return chunks;
-};
-
-
-internals.Vise.prototype.at = internals.Vise.prototype.readUInt8 = function (pos) {
-
-    const item = this._chunkAt(pos);
-    return item ? item.chunk.data[item.offset] : undefined;
-};
-
-
-internals.Vise.prototype._chunkAt = function (pos) {
-
-    if (pos < 0) {
-        return null;
-    }
-
-    pos = pos + this._offset;
-
-    for (let i = 0; i < this._chunks.length; ++i) {
-        const chunk = this._chunks[i];
-        const offset = pos - chunk.offset;
-        if (offset < chunk.length) {
-            return { chunk, offset };
-        }
-    }
-
-    return null;
-};
-
-
-internals.Vise.prototype.chunks = function () {
-
-    const chunks = [];
-
-    for (let i = 0; i < this._chunks.length; ++i) {
-        const chunk = this._chunks[i];
-        if (i === 0 &&
-            this._offset) {
-
-            chunks.push(chunk.data.slice(this._offset));
-        }
-        else {
-            chunks.push(chunk.data);
-        }
-    }
-
-    return chunks;
-};
-
-
-internals.Vise.prototype.startsWith = function (value, pos, length) {
-
-    pos = pos || 0;
-
-    length = length ? Math.min(value.length, length) : value.length;
-    if (pos + length > this.length) {                                   // Not enough length to fit value
-        return false;
-    }
-
-    const start = this._chunkAt(pos);
-    if (!start) {
-        return false;
-    }
-
-    let j = start.chunk.index;
-    for (let i = 0; j < this._chunks.length && i < length; ++j) {
-        const chunk = this._chunks[j];
-
-        let k = (j === start.chunk.index ? start.offset : 0);
-        for (; k < chunk.length && i < length; ++k, ++i) {
-            if (chunk.data[k] !== value[i]) {
-                return false;
+        if (chunks) {
+            chunks = [].concat(chunks);
+            for (let i = 0; i < chunks.length; ++i) {
+                this.push(chunks[i]);
             }
         }
     }
 
-    return true;
+    push(chunk) {
+
+        Hoek.assert(Buffer.isBuffer(chunk), 'Chunk must be a buffer');
+
+        const item = {
+            data: chunk,
+            length: chunk.length,
+            offset: this.length + this._offset,
+            index: this._chunks.length
+        };
+
+        this._chunks.push(item);
+        this.length += chunk.length;
+    }
+
+    shift(length) {
+
+        if (!length) {
+            return [];
+        }
+
+        const prevOffset = this._offset;
+        const item = this.#chunkAt(length);
+
+        let dropTo = this._chunks.length;
+        this._offset = 0;
+
+        if (item) {
+            dropTo = item.chunk.index;
+            this._offset = item.offset;
+        }
+
+        // Drop lower chunks
+
+        const chunks = [];
+        for (let i = 0; i < dropTo; ++i) {
+            const chunk = this._chunks.shift();
+            if (i === 0 &&
+                prevOffset) {
+
+                chunks.push(chunk.data.slice(prevOffset));
+            }
+            else {
+                chunks.push(chunk.data);
+            }
+        }
+
+        if (this._offset) {
+            chunks.push(item.chunk.data.slice(dropTo ? 0 : prevOffset, this._offset));
+        }
+
+        // Recalculate existing chunks
+
+        this.length = 0;
+        for (let i = 0; i < this._chunks.length; ++i) {
+            const chunk = this._chunks[i];
+            chunk.offset = this.length,
+            chunk.index = i;
+
+            this.length += chunk.length;
+        }
+
+        this.length -= this._offset;
+
+        return chunks;
+    }
+
+    readUInt8(pos) {
+
+        const item = this.#chunkAt(pos);
+        return item ? item.chunk.data[item.offset] : undefined;
+    }
+
+    at(pos) {
+
+        return this.readUInt8(pos);
+    }
+
+    #chunkAt(pos) {
+
+        if (pos < 0) {
+            return null;
+        }
+
+        pos = pos + this._offset;
+
+        for (let i = 0; i < this._chunks.length; ++i) {
+            const chunk = this._chunks[i];
+            const offset = pos - chunk.offset;
+            if (offset < chunk.length) {
+                return { chunk, offset };
+            }
+        }
+
+        return null;
+    }
+
+    chunks() {
+
+        const chunks = [];
+
+        for (let i = 0; i < this._chunks.length; ++i) {
+            const chunk = this._chunks[i];
+            if (i === 0 &&
+                this._offset) {
+
+                chunks.push(chunk.data.slice(this._offset));
+            }
+            else {
+                chunks.push(chunk.data);
+            }
+        }
+
+        return chunks;
+    }
+
+    startsWith(value, pos, length) {
+
+        pos = pos ?? 0;
+
+        length = length ? Math.min(value.length, length) : value.length;
+        if (pos + length > this.length) {                                   // Not enough length to fit value
+            return false;
+        }
+
+        const start = this.#chunkAt(pos);
+        if (!start) {
+            return false;
+        }
+
+        let j = start.chunk.index;
+        for (let i = 0; j < this._chunks.length && i < length; ++j) {
+            const chunk = this._chunks[j];
+
+            let k = (j === start.chunk.index ? start.offset : 0);
+            for (; k < chunk.length && i < length; ++k, ++i) {
+                if (chunk.data[k] !== value[i]) {
+                    return false;
+                }
+            }
+        }
+
+        return true;
+    }
 };

--- a/package.json
+++ b/package.json
@@ -19,12 +19,12 @@
     ]
   },
   "dependencies": {
-    "@hapi/hoek": "9.x.x"
+    "@hapi/hoek": "^10.0.0"
   },
   "devDependencies": {
-    "@hapi/code": "8.x.x",
+    "@hapi/code": "^9.0.0",
     "@hapi/eslint-plugin": "*",
-    "@hapi/lab": "24.x.x"
+    "@hapi/lab": "^25.0.1"
   },
   "scripts": {
     "test": "lab -a @hapi/code -t 100 -L",

--- a/test/esm.js
+++ b/test/esm.js
@@ -1,0 +1,27 @@
+'use strict';
+
+const Code = require('@hapi/code');
+const Lab = require('@hapi/lab');
+
+
+const { before, describe, it } = exports.lab = Lab.script();
+const expect = Code.expect;
+
+
+describe('import()', () => {
+
+    let Vise;
+
+    before(async () => {
+
+        Vise = await import('../lib/index.js');
+    });
+
+    it('exposes all methods and classes as named imports', () => {
+
+        expect(Object.keys(Vise)).to.equal([
+            'Vise',
+            'default'
+        ]);
+    });
+});

--- a/test/index.js
+++ b/test/index.js
@@ -2,7 +2,7 @@
 
 const Code = require('@hapi/code');
 const Lab = require('@hapi/lab');
-const Vise = require('..');
+const { Vise } = require('..');
 
 
 const internals = {};


### PR DESCRIPTION
 - Test on node v14+ and adopt some new syntax.
 - Update to node v18-compatible versions of hapi modules.
 - Made `Vise` an ES6 class— I recommend reviewing with whitespace ignored.
 - Changed export to `exports.Vise` rather than `module.exports` for more standard ESM usage.

If this looks good, this will go out as vise v5.